### PR TITLE
Add resolvconf::tail to allow /etc/resolvconf/resolv.conf.d/tail file management

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -23,7 +23,8 @@ class resolvconf (
   $nameserver = [],
   $domain     = '',
   $search     = [],
-  $options    = []
+  $options    = [],
+  $file       = '/etc/resolv.conf',
 ) {
 
   if $domain != '' and $search != [] {
@@ -31,7 +32,7 @@ class resolvconf (
   }
 
   if $nameserver != [] {
-    file { '/etc/resolv.conf':
+    file { $file:
       owner   => 'root',
       group   => 'root',
       mode    => '0644',
@@ -41,3 +42,21 @@ class resolvconf (
 
 }
 
+class resolvconf::tail (
+  $header     = 'This file is managed by Puppet, do not edit',
+  $nameserver = [],
+  $domain     = '',
+  $search     = [],
+  $options    = [],
+) {
+
+  class { 'resolvconf':
+    header     => $header,
+    nameserver => $nameserver,
+    domain     => $domain,
+    search     => $search,
+    options    => $options,
+    file       => '/etc/resolvconf/resolv.conf.d/tail',
+  }
+
+}

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -18,13 +18,13 @@
 #    search     => [ 'example.lan', 'example.com' ],
 #  }
 #
-class resolvconf (
+define resolvconf::file (
   $header     = 'This file is managed by Puppet, do not edit',
   $nameserver = [],
   $domain     = '',
   $search     = [],
   $options    = [],
-  $file       = '/etc/resolv.conf',
+  $file       = $name,
 ) {
 
   if $domain != '' and $search != [] {
@@ -42,7 +42,7 @@ class resolvconf (
 
 }
 
-class resolvconf::tail (
+class resolvconf (
   $header     = 'This file is managed by Puppet, do not edit',
   $nameserver = [],
   $domain     = '',
@@ -50,13 +50,14 @@ class resolvconf::tail (
   $options    = [],
 ) {
 
-  class { 'resolvconf':
+  $file = '/etc/resolv.conf'
+
+  resolvconf::file { $file:
     header     => $header,
     nameserver => $nameserver,
     domain     => $domain,
     search     => $search,
     options    => $options,
-    file       => '/etc/resolvconf/resolv.conf.d/tail',
   }
 
 }


### PR DESCRIPTION
The file /etc/resolvconf/resolv.conf.d/tail has the same structure and syntax than /etc/resolv.conf, so I've added a "file" parameter to resolvconf class (defaulting to previous hardcoded value) to allow the resolvconf::tail class to be based on it. This way, future enhancements to resolvoconf will benefit to depending tail class.
As it is now, the only caveat is that both are mutually exclusive due to tail defining again resolvconf base class, but since the use case is meant for OS-managed resolv.conf files as in Ubuntu, it should not break anything. The specific purpose of the tail file is to allow changes/appends to an already OS-managed resolv.conf file.
Another solution would be redefine resolvconf as a resource instead of a class, but that's going too far and maybe unnecessary due to tail file purpose.
Tested working successfully under Ubuntu Precise. Managed hosts do not have any resolv.conf file managed, just the tail file.

More info:
http://manpages.ubuntu.com/manpages/precise/man8/resolvconf.8.html#contenttoc7
http://askubuntu.com/questions/130452/how-do-i-add-a-dns-server-via-resolv-conf
