### PR TITLE
v0.1.0 upgrade

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+# We are going to ignore these directories as they shouldn't end up on github.
+pkg/
+.project

--- a/.puppet-lint.rc
+++ b/.puppet-lint.rc
@@ -1,0 +1,3 @@
+--no-autoloader_layout-check
+--no-class_inherits_from_params_class-check
+--no-80chars-check

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,11 @@
+2015-02-08 - 0.1.0
+* Added support for AIX
+* Corrected verbiage from nameserver to nameservers
+* Updated documentation
+* Added exclusive check for search + domain
+* Added hiera lookups for search domains (will mash)
+
+2015-01-01 - 0.0.4
 * Create new file definition to manage Ubuntu resolv.conf.d files (#2).
 * Add support for sortlist parameter.
 

--- a/Modulefile
+++ b/Modulefile
@@ -1,5 +1,5 @@
 name 'thias-resolvconf'
-version '0.0.3'
+version '0.1.0'
 source 'git://github.com/thias/puppet-resolvconf'
 author 'Matthias Saou'
 license 'Apache 2.0'

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Manage /etc/resolv.conf with puppet.
 * `resolvconf::file` : Definition to manage extra files.
 
 The idea is to be able to globally include the `resolvconf` class on all nodes.
-From there, hiera with puppet 3.x allows to start managing the
+From there, use hiera with puppet 3.x which allows a quick start to managing the
 `/etc/resolv.conf` file's content in a very flexible way.
 
 ## Examples
@@ -24,7 +24,7 @@ In `hieradata` somewhere :
 classes:
   - '::resolvconf'
 resolvconf::header: ''
-resolvconf::nameserver:
+resolvconf::nameservers:
   - '198.51.100.1'
   - '198.51.100.2'
 resolvconf::search:
@@ -36,10 +36,21 @@ resolvconf::search:
 This way, only nodes where the Hiera values apply get their `/etc/resolv.conf`
 file modified by Puppet.
 
-Ubuntu allows for file snippets to be used :
+Alternatively, You can also create arbitrary resolv.conf files using the
+`resolvconf::file` class:
+```puppet
+resolvconf::file { '/etc/dnsmasq-resolv.conf':
+    hiera_search => true,
+    exclusive    => false,
+    header       => 'This file is managed by Puppet for dnsmasq.',
+    nameservers  => [ '8.8.8.8', '8.8.4.4' ],
+    search       => [ 'foo.example.com', 'bar.example.com' ],
+}
+```
+
+For example, Ubuntu allows for file snippets to be used:
 ```puppet
 resolvconf::file { '/etc/resolvconf/resolv.conf.d/tail':
   nameserver => [ '198.51.100.1', '198.51.100.2' ],
 }
 ```
-

--- a/manifests/file.pp
+++ b/manifests/file.pp
@@ -1,48 +1,118 @@
-# Define: resolvconf::file
+# == Class: resolvconf::file
 #
-# Manage any resolv.conf type file with puppet. See resolv.conf(5).
+# Manage /etc/resolv.conf with puppet. See resolv.conf(5).
 #
-# Parameters:
-#  $nameserver:
-#    Array of nameservers. Default: empty
-#  $domain:
-#    Domain name. Default: empty
-#  $search:
-#    Array of search domains. Default: empty
-#  $sortlist:
-#    Array of sortlist IP-address-netmask pairs. Default: empty
-#  $options:
-#    Array of options. Default: empty
+# This class creates a resolv.conf file for the main class.  Additionally, it
+# can be used to generate resolv.conf files for other purposes.  Such as snippets
+# for Ubuntu.
 #
-# Sample Usage :
-#  resolvconf::file { '/etc/resolvconf/resolv.conf.d/tail':
-#    nameserver => [ '8.8.8.8', '8.8.4.4' ],
-#    search     => [ 'example.lan', 'example.com' ],
-#  }
+# === Parameters
+#
+# Document parameters here.
+#
+# [*nameservers*]
+#   Array of nameservers. Default: empty
+#
+# [*nameserver*] -- deprecated only here for posterity
+#   Array of nameservers. Default: empty
+#
+# [*domain*]
+#   Domain name. Default: facter value for domain
+#
+# [*search*]
+#   Array of search domains. Default: empty
+#
+# [*options*]
+#   Array of options. Default: empty
+#
+# [*hiera_search*]
+#   Boolean whether to do a Hiera lookup mashup to get all values.  Default: false
+#
+# [*exclusive*]
+#   Boolean whether domain and search are mutually exclusive.  Default: false
+#
+# [*config_template*]
+#   An alternative template to use for resolv.conf. Default: undefined
+#
+# [*owning_user*]
+#   Specify an alternative user to own the new resolv.conf file
+#
+# [*owning_group*]
+#   Specify an alternative group to own the new resolv.conf file
+#
+# === Variables
+#
+# Here you should define a list of variables that this module would require.
+#
+# [*kernel*]
+#   The kernel module is not required, but is utilized on Linux systems
+#
+# === Examples
+#
+# A simple example looks like:
+#
+#       class { 'resolvconf':
+#         nameservers => [ '8.8.8.8', '8.8.4.4' ],
+#         search      => [ 'example.lan', 'example.com' ],
+#         options     => [ 'timeout:1', 'attempts:1' ],
+#       }
+#
+# A full example looks like:
+#
+#       class { 'resolvconf':
+#         hiera_search => true,
+#         exclusive    => false,
+#         config_template => "some_other_module/resolvconf.erb",
+#         domain      => 'example.lan',
+#         nameservers => [ '8.8.8.8', '8.8.4.4' ],
+#         options     => [ 'timeout:1', 'attempts:1' ],
+#         search      => [ 'example.lan', 'example.com' ],
+#         sortlist    => [ '130.155.160.0/255.255.240.0', '130.155.0.0', ],
+#       }
+#
+# === Authors
+#
+# Josh Preston <JoshPreston@dswinc.com>
 #
 define resolvconf::file (
-  $ensure     = present,
-  $header     = 'This file is managed by Puppet, do not edit',
-  $nameserver = [],
-  $domain     = '',
-  $search     = [],
-  $sortlist   = [],
-  $options    = [],
+  $owning_user,
+  $owning_group,
+  $config_template,
+  $hiera_search    = false,
+  $exclusive       = true,
+  $ensure          = present,
+  $header          = 'This file is managed by Puppet, do not edit',
+  $nameservers     = [],
+  $domain          = '',
+  $search          = [],
+  $sortlist        = [],
+  $options         = [],
 ) {
 
-  if $domain != '' and $search != [] {
+  if $exclusive and $domain != '' and $search != [] {
     fail('The "domain" and "search" parameters are mutually exclusive.')
   }
 
-  if $nameserver != [] {
+  if $hiera_search {
+    $_search = hiera_array("${module_name}::search")
+  } else {
+    $_search = $search
+  }
+
+  if $config_template {
+    $_config_template = $config_template
+  } else {
+    $_config_template = "${module_name}/resolv.conf.erb"
+  }
+
+  if $nameservers != [] {
     file { $title:
       ensure  => $ensure,
-      owner   => 'root',
-      group   => 'root',
+      owner   => $owning_user,
+      group   => $owning_group,
       mode    => '0644',
-      content => template("${module_name}/resolv.conf.erb"),
+      content => template($_config_template),
     }
   }
 
 }
-

--- a/manifests/file.pp
+++ b/manifests/file.pp
@@ -72,7 +72,8 @@
 #
 # === Authors
 #
-# Josh Preston <JoshPreston@dswinc.com>
+# Matthias Saou
+# Josh Preston
 #
 define resolvconf::file (
   $owning_user,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,32 +1,119 @@
-# Class: resolvconf
+# == Class: resolvconf
 #
 # Manage /etc/resolv.conf with puppet. See resolv.conf(5).
 #
 # This class is just a wrapper around resolvconf::file for the main file.
 #
-# Sample Usage :
-#  class { 'resolvconf':
-#    nameserver => [ '8.8.8.8', '8.8.4.4' ],
-#    search     => [ 'example.lan', 'example.com' ],
-#  }
+# === Parameters
+#
+# Document parameters here.
+#
+# [*nameservers*]
+#   Array of nameservers. Default: empty
+#
+# [*nameserver*] -- deprecated only here for posterity
+#   Array of nameservers. Default: empty
+#
+# [*domain*]
+#   Domain name. Default: facter value for domain
+#
+# [*search*]
+#   Array of search domains. Default: empty
+#
+# [*options*]
+#   Array of options. Default: empty
+#
+# [*hiera_search*]
+#   Boolean whether to do a Hiera lookup mashup to get all values.  Default: false
+#
+# [*exclusive*]
+#   Boolean whether domain and search are mutually exclusive.  Default: false
+#
+# [*config_template*]
+#   An alternative template to use for resolv.conf. Default: undefined
+#
+# [*owning_user*]
+#   Specify an alternative user to own the new resolv.conf file.  Default: root
+#
+# [*owning_group*]
+#   Specify an alternative group to own the new resolv.conf file.  Default: undef
+#
+# === Variables
+#
+# Here you should define a list of variables that this module would require.
+#
+# [*kernel*]
+#   The kernel module is not required, but is utilized on Linux systems
+#
+# === Examples
+#
+# A simple example looks like:
+#
+#       class { 'resolvconf':
+#         nameservers => [ '8.8.8.8', '8.8.4.4' ],
+#         search      => [ 'example.lan', 'example.com' ],
+#         options     => [ 'timeout:1', 'attempts:1' ],
+#       }
+#
+# A full example looks like:
+#
+#       class { 'resolvconf':
+#         hiera_search => true,
+#         exclusive    => false,
+#         config_template => "some_other_module/resolvconf.erb",
+#         domain      => 'example.lan',
+#         nameservers => [ '8.8.8.8', '8.8.4.4' ],
+#         options     => [ 'timeout:1', 'attempts:1' ],
+#         search      => [ 'example.lan', 'example.com' ],
+#         sortlist    => [ '130.155.160.0/255.255.240.0', '130.155.0.0', ],
+#       }
+#
+# === Authors
+#
+# Josh Preston <JoshPreston@dswinc.com>
 #
 class resolvconf (
-  $header     = 'This file is managed by Puppet, do not edit',
-  $nameserver = [],
-  $domain     = '',
-  $search     = [],
-  $sortlist   = [],
-  $options    = [],
+  $hiera_search    = false,  # Backwards compatibility
+  $exclusive       = true,   # Backwards compatibility
+  $header          = 'This file is managed by Puppet, do not edit',
+  $nameservers     = [],
+  $options         = [],
+  $search          = [],
+  $sortlist        = [],
+  $nameserver      = [],     # Backwards compatibility
+  $owning_user     = 'root',
+  $owning_group,
+  $domain,
+  $config_template,
 ) {
 
+  # Backwards compatibility
+  if $nameservers == [] and $nameserver != [] {
+    notify { "${module_name}: [nameserver] is deprecated, please adjust to nameservers.": }
+    $_nameservers = $nameserver
+  }
+
+  # Change the ownership of the default file by OS
+  if !$owning_group {
+    case $::kernel {
+      'AIX'   : { $owning_group = 'system' }
+      default : { $owning_group = 'root' }
+    }
+  }
+
+  # Create the new file
   resolvconf::file { '/etc/resolv.conf':
-    header     => $header,
-    nameserver => $nameserver,
-    domain     => $domain,
-    search     => $search,
-    sortlist   => $sortlist,
-    options    => $options,
+    hiera_search    => $hiera_search,
+    exclusive       => $exclusive,
+    owning_user     => $owning_user,
+    owning_group    => $owning_group,
+    header          => $header,
+    nameservers     => $_nameservers,
+    domain          => $domain,
+    search          => $search,
+    sortlist        => $sortlist,
+    options         => $options,
+    config_template => $config_template,
   }
 
 }
-

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -70,7 +70,8 @@
 #
 # === Authors
 #
-# Josh Preston <JoshPreston@dswinc.com>
+# Matthias Saou
+# Josh Preston
 #
 class resolvconf (
   $hiera_search    = false,  # Backwards compatibility

--- a/metadata.json
+++ b/metadata.json
@@ -1,0 +1,34 @@
+{
+  "name": "thias-resolvconf",
+  "version": "0.1.0",
+  "author": "Matthias Saou",
+  "summary": "/etc/resolv.conf module",
+  "license": "Apache-2.0",
+  "source": "git://github.com/thias/puppet-resolvconf",
+  "project_page": "https://github.com/thias/puppet-resolvconf",
+  "issues_url": "https://github.com/thias/puppet-resolvconf/issues",
+  "tags": [ "resolv", "resolvconf", "resolv.conf", "dns" ],
+  "operatingsystem_support": [
+    {
+      "operatingsystem": "AIX"
+    },{
+      "operatingsystem": "CentOS"
+    },{
+      "operatingsystem": "Debian"
+    },{
+      "operatingsystem": "RedHat"
+    },{
+      "operatingsystem": "Ubuntu"
+    }
+  ],
+  "requirements": [
+    {
+      "name": "pe",
+      "version_requirement": "3.x"
+    },
+    {
+      "name": "puppet",
+      "version_requirement": "3.x"
+    }
+  ]
+}

--- a/templates/resolv.conf.erb
+++ b/templates/resolv.conf.erb
@@ -3,7 +3,7 @@
 <% end -%>
 <% if !@search.empty? -%>
 search <%= @search.join(' ') %>
-<% elsif !@domain.empty? -%>
+<% elsif !@exclusive and !@domain.empty? -%>
 search <%= @domain %>
 <% end -%>
 <% if !@domain.empty? -%>

--- a/templates/resolv.conf.erb
+++ b/templates/resolv.conf.erb
@@ -1,13 +1,13 @@
 <% if !@header.empty? -%>
 # <%= @header %>
 <% end -%>
+<% if !@domain.empty? -%>
+domain <%= @domain %>
+<% end -%>
 <% if !@search.empty? -%>
 search <%= @search.join(' ') %>
 <% elsif !@exclusive and !@domain.empty? -%>
 search <%= @domain %>
-<% end -%>
-<% if !@domain.empty? -%>
-domain <%= @domain %>
 <% end -%>
 <% if !@options.empty? -%>
 options <%= @options.join(' ') %>

--- a/templates/resolv.conf.erb
+++ b/templates/resolv.conf.erb
@@ -3,6 +3,8 @@
 <% end -%>
 <% if !@search.empty? -%>
 search <%= @search.join(' ') %>
+<% elsif !@domain.empty? -%>
+search <%= @domain %>
 <% end -%>
 <% if !@domain.empty? -%>
 domain <%= @domain %>

--- a/templates/resolv.conf.erb
+++ b/templates/resolv.conf.erb
@@ -4,7 +4,7 @@
 <% if !@domain.empty? -%>
 domain <%= @domain %>
 <% end -%>
-<% if !@search.empty? -%>
+<% if @exclusive and @domain.empty? and !@search.empty? -%>
 search <%= @search.join(' ') %>
 <% elsif !@exclusive and !@domain.empty? -%>
 search <%= @domain %>


### PR DESCRIPTION
A number of cleanups and improvements.
-  I found several instances where domain and search both needed to be specified.  I made a new parameter, `exclusive`, to allow for this check to be disabled.  Defaults to `true` to preserve existing implementations.
- Added AIX support.  It worked just fine, however, the owning group needed to be specified as `system` not `root`.
- Added .puppet-lint.rc file for puppet-git-hooks.
- Improved class documentation
- Added metadata.json for better forge integration
- Added `hiera_search` parameter to allow for hiera calls that will merge using `hiera_array`.  This allows large search lists to be generated using hiera.
- Also added a piece where domain needed to be specified
- Renamed `nameserver` to `nameservers` for readability purposes.  Left some backwards compat code just in case.
